### PR TITLE
handle encoding a cbor null in a list

### DIFF
--- a/go/cbor.go
+++ b/go/cbor.go
@@ -1272,6 +1272,10 @@ func (enc *Encoder) writeReflection(rv reflect.Value) error {
 		rv = reflect.ValueOf(enc.filter(rv.Interface()))
 	}
 
+	if ! rv.IsValid() {
+	   return enc.tagAuxOut(cbor7, uint64(cborNull))
+	}
+
 	if v, ok := rv.Interface().(MarshallValue); ok {
 		return v.ToCBOR(enc.out, enc)
 	} else if v, ok := rv.Interface().(SimpleMarshallValue); ok {


### PR DESCRIPTION
rv.Interface() was throwing for nil. Handle it early and return.